### PR TITLE
Modify so the asyncs so they are invoked seperatly

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -287,12 +287,10 @@ Target "Debug" (fun _ ->
                 info.WorkingDirectory <- srcDir
                 info.Arguments <- " fable npm-run start") TimeSpan.MaxValue
         if result <> 0 then failwith "fable shut down." }
+    Async.Start dotnetwatch
 
-    let reactNativeTool = async {  run reactNativeTool "run-android" "" }
-
-    Async.Parallel [| dotnetwatch; reactNativeTool |]
-    |> Async.RunSynchronously
-    |> ignore
+    let reactNativeTool = async { run reactNativeTool "run-android" "" }
+    Async.Start reactNativeTool
 )
 
 FinalTarget "KillProcess" (fun _ ->


### PR DESCRIPTION
Async.Parallel eats the failwithf when the platformTool function does not find a command like `reactNative` which makes diagnosis difficult if a tool is missing.

Addresses issues in #39 