### PR TITLE
tryPick from list of platform tools

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -96,7 +96,7 @@ let androidSDKPath =
 
 let adbTool = platformTool [androidSDKPath </> "platform-tools/adb"] [androidSDKPath </> "platform-tools/adb.exe"]
 
-let scpTool = platformTool  ["scp"] [ @"C:\Program Files\Git\usr\bin\scp.exe"; @"C:\Program Files (x86)\Git\usr\bin\scp.exe"]
+let scpTool = platformTool ["scp"] [@"C:\Program Files\Git\usr\bin\scp.exe"; @"C:\Program Files (x86)\Git\usr\bin\scp.exe"]
 let sshTool = platformTool ["ssh"] [@"C:\Program Files\Git\usr\bin\ssh.exe"; @"C:\Program Files (x86)\Git\usr\bin\ssh.exe"]
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -39,23 +39,23 @@ let configuration = "Release"
 let msg =  release.Notes |> List.fold (fun r s -> r + s + "\n") ""
 let releaseMsg = (sprintf "Release %s\n" release.NugetVersion) + msg
 
-let run' timeout (cmd:Lazy<string>) args dir =
+let run' timeout (cmd:string) args dir =
     if execProcess (fun info ->
-        info.FileName <- cmd.Force()
+        info.FileName <- cmd
         if not (String.IsNullOrWhiteSpace dir) then
             info.WorkingDirectory <- dir
         info.Arguments <- args
     ) timeout |> not then
-        failwithf "Error while running '%s' with args: %s" (cmd.Force()) args
+        failwithf "Error while running '%s' with args: %s" cmd args
 
 let run = run' System.TimeSpan.MaxValue
 
 
-let platformTool tool winTool = lazy(
+let platformTool tool winTool =
     let tool = if isUnix then tool else winTool
     tool
     |> ProcessHelper.tryFindFileOnPath
-    |> function Some t -> t | _ -> failwithf "%s not found" tool)
+    |> function Some t -> t | _ -> failwithf "%s not found" tool
 
 let nodeTool = platformTool "node" "node.exe"
 let yarnTool = platformTool "yarn" "yarn.cmd"
@@ -96,8 +96,8 @@ let androidSDKPath =
 
 let adbTool = platformTool (androidSDKPath </> "platform-tools/adb") (androidSDKPath </> "platform-tools/adb.exe")
 
-let scpTool = platformTool  "scp" @"C:\Program Files (x86)\Git\usr\bin\scp.exe"
-let sshTool = platformTool "ssh" @"C:\Program Files (x86)\Git\usr\bin\ssh.exe"
+let scpTool = platformTool  "scp" @"C:\Program Files\Git\usr\bin\scp.exe"
+let sshTool = platformTool "ssh" @"C:\Program Files\Git\usr\bin\ssh.exe"
 
 
 setEnvironVar "ANDROID_HOME" androidSDKPath

--- a/build.fsx
+++ b/build.fsx
@@ -24,6 +24,7 @@ let releaseNotesData =
 
 let outDir = "./out"
 let deployDir = "./deploy"
+let nodeModulesBinDir = "./node_modules/.bin"
 
 let release = List.head releaseNotesData
 let packageVersion = SemVerHelper.parse release.NugetVersion
@@ -39,26 +40,25 @@ let configuration = "Release"
 let msg =  release.Notes |> List.fold (fun r s -> r + s + "\n") ""
 let releaseMsg = (sprintf "Release %s\n" release.NugetVersion) + msg
 
-let run' timeout (cmd:string) args dir =
+let run' timeout (cmd:Lazy<string>) args dir =
     if execProcess (fun info ->
-        info.FileName <- cmd
+        info.FileName <- cmd.Force()
         if not (String.IsNullOrWhiteSpace dir) then
             info.WorkingDirectory <- dir
         info.Arguments <- args
     ) timeout |> not then
-        failwithf "Error while running '%s' with args: %s" cmd args
+        failwithf "Error while running '%s' with args: %s" (cmd.Force()) args
 
 let run = run' System.TimeSpan.MaxValue
 
-
-let platformTool tool winTool =
+let platformTool tool winTool = lazy(
     let tool = if isUnix then tool else winTool
     tool
-    |> ProcessHelper.tryFindFileOnPath
-    |> function Some t -> t | _ -> failwithf "%s not found" tool
+    |> List.tryPick ProcessHelper.tryFindFileOnPath
+    |> function Some t -> t | _ -> failwithf "%A not found" tool)
 
-let nodeTool = platformTool "node" "node.exe"
-let yarnTool = platformTool "yarn" "yarn.cmd"
+let nodeTool = platformTool ["node"] ["node.exe"]
+let yarnTool = platformTool ["yarn"] ["yarn.cmd"]
 
 let srcDir = __SOURCE_DIRECTORY__ </> "src"
 
@@ -76,8 +76,8 @@ let runDotnet workingDir args =
             info.Arguments <- args) TimeSpan.MaxValue
     if result <> 0 then failwithf "dotnet %s failed" args
 
-let gradleTool = platformTool "android/gradlew" ("android" </> "gradlew.bat" |> FullName)
-let reactNativeTool = platformTool "react-native" "react-native.cmd"
+let gradleTool = platformTool ["android/gradlew"] ["android" </> "gradlew.bat" |> FullName]
+let reactNativeTool = platformTool [nodeModulesBinDir </> "react-native"] [nodeModulesBinDir </> "react-native.cmd"]
 
 let androidSDKPath =
     match environVarOrNone "ANDROID_HOME" with
@@ -94,10 +94,10 @@ let androidSDKPath =
             if Directory.Exists p3 then FullName p3 else
             failwithf "Can't find Android SDK in %s, please set ANDROID_HOME enviromental variable" p3
 
-let adbTool = platformTool (androidSDKPath </> "platform-tools/adb") (androidSDKPath </> "platform-tools/adb.exe")
+let adbTool = platformTool [androidSDKPath </> "platform-tools/adb"] [androidSDKPath </> "platform-tools/adb.exe"]
 
-let scpTool = platformTool  "scp" @"C:\Program Files\Git\usr\bin\scp.exe"
-let sshTool = platformTool "ssh" @"C:\Program Files\Git\usr\bin\ssh.exe"
+let scpTool = platformTool  ["scp"] [ @"C:\Program Files\Git\usr\bin\scp.exe"; @"C:\Program Files (x86)\Git\usr\bin\scp.exe"]
+let sshTool = platformTool ["ssh"] [@"C:\Program Files\Git\usr\bin\ssh.exe"; @"C:\Program Files (x86)\Git\usr\bin\ssh.exe"]
 
 
 setEnvironVar "ANDROID_HOME" androidSDKPath
@@ -123,6 +123,8 @@ Target "Clean" (fun _ ->
     CleanDir deployDir
     ProcessHelper.killProcess "node"
     !! "./**/AppiumLog.txt" |> Seq.iter File.Delete
+    CleanDir "./android/build"
+    CleanDir "./android/app/build"
 )
 
 FinalTarget "CloseAndroid" (fun _ ->


### PR DESCRIPTION
Here is what I had to change to get it to run.

There was no error to indicate that `reactive-native.cmd` wasn't found until I removed the `Lazy`. It also does not look for the tools in `nodes_modules\.bin` and it probably should. To workaround it, I ran:
``` ps1
$env:path = "$pwd\node_modules\.bin;$env:path"
.\build.cmd debug
```

The default git version downloadable at https://git-scm.com/downloads is the 64-bit version. Perhaps this should look for 64-bit and 32-bit in that order. I only have the 64-bit version installed.